### PR TITLE
Add link to Kong community call agenda

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 - [`#kong` on Freenode](http://webchat.freenode.net/?channels=kong)
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/kong)
 - [Meetup](https://www.meetup.com/topics/kong/all/)
+- [Kong Community Calls](https://docs.google.com/document/d/1heIynPTVcHn13BXMJO0KiOr8bTmbhzVxJe5yajp4Xz4)
 
 
 ## Self Promotion


### PR DESCRIPTION
The [community call](https://discuss.konghq.com/t/join-the-first-ever-kong-community-call/1881) is relatively new so I wasn't sure what a good link would be; the agenda is updated with past recordings (only one right now), so it seemed like the safest bet for now.