### PR TITLE
Adding skull_island CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 - [decK](https://github.com/hbagdi/deck) - CLI tool to configure Kong declaratively using a single config file **(Compatiable with Kong 1.x)**
 - [Kongfig](https://github.com/mybuilder/kongfig) - Declarative configuration for Kong
 - [Ansible Kong](https://github.com/wunzeco/ansible-kong) - Installs and Configures Kong with Ansible
+- [Skull Island](https://github.com/jgnagy/skull_island) - CLI tool and Ruby SDK for Kong 1.x. Supports templates and distributed configuration.
 
 
 ## Custom Plugins


### PR DESCRIPTION
Adding a link to the [Skull Island](https://github.com/jgnagy/skull_island) CLI tool and Ruby SDK. The tool is awesome because:

* I'm biased (I wrote it)
* It is _both_ a CLI tool and an SDK for the Kong Admin API
* It can help people migrate to 1.1+
* It supports YAML + embedded ruby (it allows for limited templating)
    * Specifically, IDs can be looked up using `lookup()`, allowing portable configuration
* The YAML configuration supports a `project` key that can be used to add, update, or remove configuration
    * This leverages special, hidden tags under-the-hood, meaning maintaining state is done **within** Kong itself
    * This works wonderfully from a CI perspective because it is easy to have a build stage that triggers `skull_island import` on project-specific Kong config
* It is open-source!